### PR TITLE
fix: inline combined or with punctuation * characters where not parsed compleetly

### DIFF
--- a/examples/main.html
+++ b/examples/main.html
@@ -81,4 +81,4 @@ mollit anim id est laborum.</p><p>Lorem ipsum dolor sit amet, consectetur adipis
 dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
 ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
 fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-mollit anim id est laborum.</p><h3>Blank lines</h3><h6>1</h6><h6>6</h6><h1>Naive support</h1><h1>Bands</h1><hr/><h2>The Who</h2><p>Who are you? <strong>bold</strong> who!.</p><h2>Foo Fighters</h2><p>Learning to walk again</p><hr/><hr/><hr/><hr/><h1>Artists</h1></body></html>
+mollit anim id est laborum.</p><h3>Blank lines</h3><h6>1</h6><h6>6</h6><h1>Naive support</h1><h2>Decoration</h2><h3>Bold</h3><p>Some <strong>bold</strong> text</p><h3>Italic</h3><p>Some <em>italic</em> text</p><h3>Combination of inlines</h3><p>Some <strong><em>bold and italic</em></strong> text</p><h1>Bands</h1><hr/><h2>The Who</h2><p>Who are you? <strong>bold</strong> who!.</p><h2>Foo Fighters</h2><p>Learning to walk again</p><hr/><hr/><hr/><hr/><h1>Artists</h1></body></html>

--- a/examples/main.md
+++ b/examples/main.md
@@ -70,6 +70,20 @@ mollit anim id est laborum.
 
 # Naive support
 
+## Decoration
+
+### Bold
+
+Some **bold** text
+
+### Italic
+
+Some *italic* text
+
+### Combination of inlines
+
+Some ***bold and italic*** text
+
 # Bands
 
 ======

--- a/src/compiler/__snapshots__/compiler.test.js.snap
+++ b/src/compiler/__snapshots__/compiler.test.js.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#compiler .compile().setSource().output() returns a string 1`] = `
-"<!DOCTYPE html>
-        <style>
-            blockquote {
-                margin: 1.5em 40px;
-                padding: 0 1em;
-                border-left: 5px solid #ddd;
-                background-color: #f9f9f9;
-                padding: 0.5em 10px;
-              }
-        </style>
-        <html><head><title>Markdown</title></head><body><h1>Hello World</h1></body></html>"
-`;
+exports[`#compiler .compile().setSource().output() returns a string 1`] = `"<!DOCTYPE html><style>null</style><html><head><title>Markdown</title></head><body><h1>Hello World</h1></body></html>"`;
 
-exports[`#compiler complete chain of methods 1`] = `
-"<!DOCTYPE html>
-        <style>
-            blockquote {
-                margin: 1.5em 40px;
-                padding: 0 1em;
-                border-left: 5px solid #ddd;
-                background-color: #f9f9f9;
-                padding: 0.5em 10px;
-              }
-        </style>
-        <html><head><title>Markdown</title></head><body><h1>Hello World</h1></body></html>"
-`;
+exports[`#compiler complete chain of methods 1`] = `"<!DOCTYPE html><style>null</style><html><head><title>Markdown</title></head><body><h1>Hello World</h1></body></html>"`;

--- a/src/parser/__snapshots__/parser.test.js.snap
+++ b/src/parser/__snapshots__/parser.test.js.snap
@@ -1,76 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`parser spec with fenced code block 1`] = `
-"<!DOCTYPE html>
-        <style>
-            blockquote {
-                margin: 1.5em 40px;
-                padding: 0 1em;
-                border-left: 5px solid #ddd;
-                background-color: #f9f9f9;
-                padding: 0.5em 10px;
-              }
-        </style>
-        <html><head><title>Markdown</title></head><body><pre><code>function foo(x) {
+"<!DOCTYPE html><style>undefined</style><html><head><title>Markdown</title></head><body><pre><code>function foo(x) {
   return 3
 }</code></pre></body></html>"
 `;
 
-exports[`parser spec with heading tokens 1`] = `
-"<!DOCTYPE html>
-        <style>
-            blockquote {
-                margin: 1.5em 40px;
-                padding: 0 1em;
-                border-left: 5px solid #ddd;
-                background-color: #f9f9f9;
-                padding: 0.5em 10px;
-              }
-        </style>
-        <html><head><title>Markdown</title></head><body><h1>foo <strong>bar</strong> baz</h1></body></html>"
-`;
+exports[`parser spec with heading tokens 1`] = `"<!DOCTYPE html><style>undefined</style><html><head><title>Markdown</title></head><body><h1>foo <strong>bar</strong> baz</h1></body></html>"`;
 
 exports[`parser spec with indented code block 1`] = `
-"<!DOCTYPE html>
-        <style>
-            blockquote {
-                margin: 1.5em 40px;
-                padding: 0 1em;
-                border-left: 5px solid #ddd;
-                background-color: #f9f9f9;
-                padding: 0.5em 10px;
-              }
-        </style>
-        <html><head><title>Markdown</title></head><body><pre><code>a simple
+"<!DOCTYPE html><style>undefined</style><html><head><title>Markdown</title></head><body><pre><code>a simple
   indented code block</code></pre></body></html>"
 `;
 
 exports[`parser spec with paragraphs 1`] = `
-"<!DOCTYPE html>
-        <style>
-            blockquote {
-                margin: 1.5em 40px;
-                padding: 0 1em;
-                border-left: 5px solid #ddd;
-                background-color: #f9f9f9;
-                padding: 0.5em 10px;
-              }
-        </style>
-        <html><head><title>Markdown</title></head><body><p>foo
+"<!DOCTYPE html><style>undefined</style><html><head><title>Markdown</title></head><body><p>foo
 bar
 baz</p></body></html>"
 `;
 
-exports[`parser spec with thematic break 1`] = `
-"<!DOCTYPE html>
-        <style>
-            blockquote {
-                margin: 1.5em 40px;
-                padding: 0 1em;
-                border-left: 5px solid #ddd;
-                background-color: #f9f9f9;
-                padding: 0.5em 10px;
-              }
-        </style>
-        <html><head><title>Markdown</title></head><body><hr/><hr/><hr/></body></html>"
-`;
+exports[`parser spec with thematic break 1`] = `"<!DOCTYPE html><style>undefined</style><html><head><title>Markdown</title></head><body><hr/><hr/><hr/></body></html>"`;

--- a/src/tokenizer/__snapshots__/tokenizer.test.js.snap
+++ b/src/tokenizer/__snapshots__/tokenizer.test.js.snap
@@ -128,6 +128,179 @@ exports[`indented code block should return the indented_code_block token 1`] = `
 ]
 `;
 
+exports[`inline text bold 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "raw": "foo",
+            "text": "foo",
+            "type": "text_inline",
+          },
+        ],
+        "raw": "**foo**",
+        "text": "foo",
+        "type": "bold",
+      },
+    ],
+    "raw": "**foo**",
+    "text": "**foo**",
+    "type": "paragraph",
+  },
+]
+`;
+
+exports[`inline text bold and italic 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "raw": "foo bar",
+                "text": "foo bar",
+                "type": "text_inline",
+              },
+            ],
+            "raw": "*foo bar*",
+            "text": "foo bar",
+            "type": "italic",
+          },
+        ],
+        "raw": "***foo bar***",
+        "text": "*foo bar*",
+        "type": "bold",
+      },
+    ],
+    "raw": "***foo bar***",
+    "text": "***foo bar***",
+    "type": "paragraph",
+  },
+]
+`;
+
+exports[`inline text bold and italic and text_inline 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "raw": "bold and italic",
+                "text": "bold and italic",
+                "type": "text_inline",
+              },
+            ],
+            "raw": "*bold and italic*",
+            "text": "bold and italic",
+            "type": "italic",
+          },
+        ],
+        "raw": "***bold and italic***",
+        "text": "*bold and italic*",
+        "type": "bold",
+      },
+      {
+        "raw": "text",
+        "text": "text",
+        "type": "text_inline",
+      },
+    ],
+    "raw": "***bold and italic***text",
+    "text": "***bold and italic***text",
+    "type": "paragraph",
+  },
+]
+`;
+
+exports[`inline text char_inline 1`] = `
+[
+  {
+    "children": [
+      {
+        "raw": "*",
+        "text": "*",
+        "type": "text_inline",
+      },
+    ],
+    "raw": "*",
+    "text": "*",
+    "type": "paragraph",
+  },
+]
+`;
+
+exports[`inline text inline unmatched asterisks 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "raw": "*abc",
+            "text": "*abc",
+            "type": "text_inline",
+          },
+        ],
+        "raw": "***abc**",
+        "text": "*abc",
+        "type": "bold",
+      },
+    ],
+    "raw": "***abc**",
+    "text": "***abc**",
+    "type": "paragraph",
+  },
+]
+`;
+
+exports[`inline text italic 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "raw": "foo",
+            "text": "foo",
+            "type": "text_inline",
+          },
+        ],
+        "raw": "*foo*",
+        "text": "foo",
+        "type": "italic",
+      },
+    ],
+    "raw": "*foo*",
+    "text": "*foo*",
+    "type": "paragraph",
+  },
+]
+`;
+
+exports[`inline text text_inline 1`] = `
+[
+  {
+    "children": [
+      {
+        "raw": "foo",
+        "text": "foo",
+        "type": "text_inline",
+      },
+    ],
+    "raw": "foo",
+    "text": "foo",
+    "type": "paragraph",
+  },
+]
+`;
+
 exports[`paragraph should return one token on multiple lines 1`] = `
 [
   {

--- a/src/tokenizer/lexer.js
+++ b/src/tokenizer/lexer.js
@@ -103,6 +103,13 @@ const textInline = (src) => {
     return { raw, type, text };
 }
 
+const charInline = (src) => {
+    const type = 'text_inline';
+    const raw = src[0];
+    const text = raw;
+    return { raw, type, text };
+}
+
 const bold = (src) => {
     const match = src.match(regex.bold);
     if (match) {
@@ -197,6 +204,7 @@ export default {
     leftFlankingDelimiterRun,
     rightFlankingDelimiterRun,
     textInline,
+    charInline,
     bold,
     italic,
     blockquote,

--- a/src/tokenizer/regex.js
+++ b/src/tokenizer/regex.js
@@ -30,8 +30,8 @@ const regex = {
     blockquote: /^> {0,}(.*)(?:\n|$)/,
 
     // Inline
-    bold: /^\*\*([\w\W]*?)\*\*/,
-    italic: /^\*(.*?)\*/,
+    bold: /^\*\*([\w\W]*)\*\*/,
+    italic: /^\*(.*)\*/,
 }
 
 export default regex;

--- a/src/tokenizer/tokenizer.js
+++ b/src/tokenizer/tokenizer.js
@@ -60,6 +60,7 @@ const tokenizeBlocks = (src) => {
 
 const tokenizeInline = (src) => {
     const tokens = [];
+    let previousToken = null;
 
     while (src) {
         let token = null;
@@ -67,27 +68,41 @@ const tokenizeInline = (src) => {
         if (token = lexer.bold(src)) {
             src = src.substring(token.raw.length);
             token.children = tokenizeInline(token.text);
-            tokens.push(token);
-            continue
         }
 
-        if (token = lexer.italic(src)) {
+        else if (token = lexer.italic(src)) {
             src = src.substring(token.raw.length);
             token.children = tokenizeInline(token.text);
-            tokens.push(token);
-            continue
         }
 
-        if (token = lexer.textInline(src)) {
+        else if (token = lexer.textInline(src)) {
             src = src.substring(token.raw.length);
-            tokens.push(token);
-            continue
+
+            if (previousToken && previousToken.type === 'text_inline') {
+                previousToken.text += token.text;
+                previousToken.raw += token.raw;
+                continue
+            }
+        }
+
+        else if (token = lexer.charInline(src)) {
+            src = src.substring(token.raw.length);
+
+            if (previousToken && previousToken.type === 'text_inline') {
+                previousToken.text += token.text;
+                previousToken.raw += token.raw;
+                continue
+            }
         }
 
         // Throws error if the src is not empty and no token is matched
-        if (src) {
+        else if (src) {
             throw new Error('Infinite loop', src);
         }
+
+        tokens.push(token);
+        previousToken = token;
+
     }
 
     return tokens;

--- a/src/tokenizer/tokenizer.test.js
+++ b/src/tokenizer/tokenizer.test.js
@@ -59,3 +59,47 @@ describe("blank line", () => {
         expect(tokens).toMatchSnapshot();
     });
 })
+
+describe("inline text", () => {
+    test("bold", () => {
+        const src = '**foo**';
+        const tokens = tokenize(src);
+        expect(tokens).toMatchSnapshot();
+    });
+
+    test("italic", () => {
+        const src = '*foo*';
+        const tokens = tokenize(src);
+        expect(tokens).toMatchSnapshot();
+    });
+
+    test("text_inline", () => {
+        const src = 'foo';
+        const tokens = tokenize(src);
+        expect(tokens).toMatchSnapshot();
+    });
+
+    test("char_inline", () => {
+        const src = '*';
+        const tokens = tokenize(src);
+        expect(tokens).toMatchSnapshot();
+    });
+
+    test("bold and italic", () => {
+        const src = '***foo bar***';
+        const tokens = tokenize(src);
+        expect(tokens).toMatchSnapshot();
+    });
+
+    test("bold and italic and text_inline", () => {
+        const src = '***bold and italic***text';
+        const tokens = tokenize(src);
+        expect(tokens).toMatchSnapshot();
+    });
+
+    test("inline unmatched asterisks", () => {
+        const src = '***abc**';
+        const tokens = tokenize(src);
+        expect(tokens).toMatchSnapshot();
+    });
+})


### PR DESCRIPTION
# Arreglar parseo de textos inline

## Problema

Al parsear los distintos tokens inline de textos, al combinarse a veces se entraba en un bucle infinito si se tenían caracteres de puntuación como `*`. Por ejemplo `***foo**` crasheaba el parser porque reconocia el bold, pero luego se quedaba pegado en el `*foo` durante la recursión.

## Solución

Se añadió un lexer por defecto que siempre ingiere un caracter y genera un token de tipo `text_inline`. Al igual que los párrafos se hizo que si el token anterior es del tipo `text_inline` se hace un merge de ambos tokens en uno solo.

## Tests
Se añadieron multiples tests que replicaban el problema y fueron corregidos.